### PR TITLE
fix: exception on minify empty style

### DIFF
--- a/src/tokens/tag.php
+++ b/src/tokens/tag.php
@@ -516,7 +516,7 @@ class tag implements token {
 					$attributes[$key] = null;
 
 				// minify style tag
-				} elseif ($key === 'style' && $minify['attributes']['style']) {
+				} elseif ($key === 'style' && $minify['attributes']['style'] && !empty($attributes[$key])) {
 					$attributes[$key] = \trim(\str_replace(
 						['  ', ' : ', ': ', ' :', ' ; ', ' ;', '; '],
 						[' ', ':', ':', ':', ';', ';', ';'],


### PR DESCRIPTION
This PR fix a problem that sometimes breaks the minify() with a html like `<div style class="somediv">....</div>`

When the element has a standalone style attribute.