### PR TITLE
Fixes issue with unreliable parse_url for relative URIs

### DIFF
--- a/src/tokens/tag.php
+++ b/src/tokens/tag.php
@@ -430,8 +430,8 @@ class tag implements token {
 			if ($minify['urls'] && $attributes[$key] && \in_array($key, $attr['urls'], true) && (!\in_array($tag, \array_keys($attr['urlskip']), true) || $this->hasAttribute($attributes, $attr['urlskip'][$tag]))) {
 
 				// make folder variables
-				if ($folder === null && isset($_SERVER['REQUEST_URI'])) {
-					if (($folder = \parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)) !== null) {
+				if ($folder === null && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
+					if (($folder = \parse_url('//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH)) !== null) {
 						if (\mb_substr($folder, -1) !== '/') {
 							$folder = \dirname($folder).'/';
 						}


### PR DESCRIPTION
I stumbled over an issue where I got an exception for a URL like `https://example.com/articles/page:2`. 

As far as I know, this is a totally valid URL, and is parsed just fine when passed to PHP’s `parse_url` function. However, `parse_url` returns `false` when used with `$_SERVER['REQUEST_URI']`, as it only contains the `/articles/page:2` part of the URL.

As noted on [php.net](https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-notes):

> This function may not give correct results for relative or invalid URLs [...]

and

> This function is intended specifically for the purpose of parsing URLs and not URIs.