### PR TITLE
Adds missing strikethrough to inline elements

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -35,7 +35,7 @@ class config {
 		$default = [
 			'elements' => [
 				'inline' => [
-					'b', 'u', 'big', 'i', 'small', 'ttspan', 'em', 'a', 'strong', 'sub', 'sup', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd', 'strong', 'samp', 'var', 'span'
+					'b', 'u', 'big', 'i', 'small', 'ttspan', 'em', 'a', 'strong', 'sub', 'sup', 'abbr', 'acronym', 'cite', 'code', 'dfn', 'em', 'kbd', 'strong', 'samp', 'var', 'span', 's'
 				],
 				'singleton' => [
 


### PR DESCRIPTION
Just noticed that the [strikethrough element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s) is missing from the default configuration’s inline elements, which removes spaces around the element.